### PR TITLE
Capture all signals and improve code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,15 @@
 
 all: build
 
-build:
-	-gcc -Wall -std=c99 -o pidunu *.c -static
+build: pidunu
 
-debug:
-	-gcc -g -D_DEBUG -Wall -std=c99 -o pidunu_dbg *.c -static
+debug: pidunu_dbg
+
+pidunu: pidunu.c
+	-gcc -Wall -std=c99 -o pidunu pidunu.c -static
+
+pidunu_dbg: pidunu.c
+	-gcc -g -D_DEBUG -Wall -std=c99 -o pidunu_dbg pidunu.c -static
 
 test: debug
 	py.test -vv --capture=no test/
@@ -15,4 +19,4 @@ clean:
 	-rm *.o
 
 check-syntax:
-	-gcc -Wall -std=c99 -o /dev/null  -S ${CHK_SOURCES}
+	-gcc -Wall -std=c99 -o /dev/null -S ${CHK_SOURCES}

--- a/pidunu.c
+++ b/pidunu.c
@@ -35,7 +35,7 @@ void sig_handler(int signo) {
 
 void register_signal(int signo, const char* signame){
   if (signal(signo, sig_handler) == SIG_ERR) {
-    debug_print("failed to setup %s; errno:%d", signame, errno);
+    debug_print("failed to setup %s; errno: %d", signame, errno);
     exit(-2);
   };
 }
@@ -88,12 +88,12 @@ int pid_one(pid_t child_pid) {
     pid = wait(&status);
     if (pid == child_pid) {
       // the spawned child just terminated
-      debug_print("child_died:%d\n", pid);
+      debug_print("child_died: %d\n", pid);
       return WEXITSTATUS(status);
     }
     if(DEBUG)  // will get optimized away by the compiler
       if(pid!=-1)  // ignore we might have no children in a suitable state
-        debug_print("reaped_orphan:%d\n", pid);
+        debug_print("reaped_orphan: %d\n", pid);
   }
   return 256;
 }
@@ -103,7 +103,7 @@ void execute(int argc, char** argv) {
     return;
   char* cmd = argv[1];
   char** args = argv+1;
-  debug_print("exec:%s\n", cmd);
+  debug_print("exec: %s\n", cmd);
   if (execvp(cmd, args) == -1) {
     fprintf(stderr, "failed to exec %s, errno is %d\n", cmd, errno);
   }
@@ -116,10 +116,10 @@ int main(int argc, char** argv) {
     fprintf(stderr, "failed to fork, errno: %d\n", errno);
     return EX_OSERR;
   } else if (pid > 0) {
-    debug_print("child_pid:%d\n", pid);
+    debug_print("child_pid: %d\n", pid);
     return pid_one(pid);
   } else if (pid == 0) {
-    debug_print("fork=>0:%d\n", getpid());
+    debug_print("fork=>0: %d\n", getpid());
     execute(argc, argv);
     return EX_OSERR; // program should have called exec and we should never get here
   }

--- a/test/test_term.py
+++ b/test/test_term.py
@@ -76,14 +76,14 @@ def test_sigterm(container_fixture):
     expected = {}
     expected[1] = [
         "pidunu:main",
-        "pidunu:child_pid:{}".format(child_pid),
+        "pidunu:child_pid: {}".format(child_pid),
         "pidunu:pid_one",
         # "pidunu:sig_handler:{}".format(signal.SIGTERM),
-        "pidunu:child_died:{}".format(child_pid),
+        "pidunu:child_died: {}".format(child_pid),
     ]
     expected[child_pid] = [
-        "pidunu:fork=>0:{}".format(child_pid),
-        "pidunu:exec:/usr/bin/python3",
+        "pidunu:fork=>0: {}".format(child_pid),
+        "pidunu:exec: /usr/bin/python3",
         "term_py:start",
         "term_py:SIGTERM",
     ]
@@ -109,14 +109,14 @@ def test_reaping(container_fixture):
     expected = {}
     expected[1] = [
         "pidunu:main",
-        "pidunu:child_pid:{}".format(child_pid),
+        "pidunu:child_pid: {}".format(child_pid),
         "pidunu:pid_one",
-        "pidunu:reaped_orphan:{}".format(child_pid+2),
-        "pidunu:child_died:{}".format(child_pid),
+        "pidunu:reaped_orphan: {}".format(child_pid+2),
+        "pidunu:child_died: {}".format(child_pid),
     ]
     expected[child_pid] = [
-        "pidunu:fork=>0:{}".format(child_pid),
-        "pidunu:exec:/usr/bin/python3",
+        "pidunu:fork=>0: {}".format(child_pid),
+        "pidunu:exec: /usr/bin/python3",
     ]
     expected[child_pid+2] = [
         "child3 is done",
@@ -151,8 +151,8 @@ def test_signals(container_fixture):
     p1_logs = logs[1]
     child_pid = int(p1_logs[1].rsplit(":", 1)[-1])
     expected = [
-        "pidunu:fork=>0:{}".format(child_pid),
-        "pidunu:exec:/usr/bin/python3",
+        "pidunu:fork=>0: {}".format(child_pid),
+        "pidunu:exec: /usr/bin/python3",
         "signals:start",
     ] + expected_child_output
     assert logs[child_pid] == expected

--- a/test/test_term.py
+++ b/test/test_term.py
@@ -146,7 +146,6 @@ def test_signals(container_fixture):
         expected_line = "signals:{}:{}".format(name, signo)
         expected_child_output.append(expected_line)
         client.kill(container.get("Id"), signo)
-        print("expected: {}".format(expected_line))
         stream.wait(re.compile(".*"+expected_line))
     logs = stream.split_logs_by_pid()
     p1_logs = logs[1]


### PR DESCRIPTION
Changes:
- Catch all signals
- Only run gcc when target is not up to date
- Fix some minor code style issues
- Reformat all debug output

I think this is mostly what #1 does, but it does not break the tests.
